### PR TITLE
Fix power 0 canonicalization

### DIFF
--- a/src/canon/canonicalizer.rs
+++ b/src/canon/canonicalizer.rs
@@ -1161,6 +1161,15 @@ impl CanonContext {
             return CanonExpr::Linear(cx);
         }
 
+        if p.abs() < 1e-10 {
+            // x^0 = 1 elementwise.
+            return CanonExpr::Linear(LinExpr::constant(DMatrix::from_element(
+                cx.shape.rows(),
+                cx.shape.cols(),
+                1.0,
+            )));
+        }
+
         // Create auxiliary variable t for the result
         let (t_var_id, t) = self.new_nonneg_aux_var(cx.shape.clone());
         let _ = t_var_id;

--- a/tests/canon_tests.rs
+++ b/tests/canon_tests.rs
@@ -186,6 +186,18 @@ fn test_power_zero_is_constant_one() {
 }
 
 #[test]
+fn test_power_zero_vector_is_constant_one_elementwise() {
+    let x = variable(3);
+
+    let sol = Problem::minimize(sum(&power(&x, 0.0)))
+        .subject_to([x.ge(1.0)])
+        .solve()
+        .expect("problem should solve");
+
+    assert!((sol.value.unwrap() - 3.0).abs() < TOL);
+}
+
+#[test]
 fn test_power_two_is_elementwise() {
     let x = variable(2);
 

--- a/tests/canon_tests.rs
+++ b/tests/canon_tests.rs
@@ -174,6 +174,18 @@ fn test_quad_over_lin_objective_variable_denominator() {
 }
 
 #[test]
+fn test_power_zero_is_constant_one() {
+    let x = variable(());
+
+    let sol = Problem::minimize(power(&x, 0.0))
+        .subject_to([x.ge(1.0)])
+        .solve()
+        .expect("problem should solve");
+
+    assert!((sol.value.unwrap() - 1.0).abs() < TOL);
+}
+
+#[test]
 fn test_power_two_is_elementwise() {
     let x = variable(2);
 


### PR DESCRIPTION
Fixes canonicalization for `power(x, 0.0)`.

Previously, `power` canonicalization handled `p == 1` specially but still routed `p == 0` through the power-cone path, and introduces wrong cone structure for an expression that should simply be constant one.

The canonicalizer now returns an elementwise constant-one `LinExpr` with the same shape as the input.